### PR TITLE
Fix to summary stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-test-report"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "askama_escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-test-report"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
The stats only recorded the final "suite" event, the `record(...)` function is now updated to add up the stats in all "suite" events to maintain a running total.

Fixes #5